### PR TITLE
Fix: Separate session loading states to prevent InputBar streaming during refresh

### DIFF
--- a/src/screens/SessionListScreen.tsx
+++ b/src/screens/SessionListScreen.tsx
@@ -30,7 +30,7 @@ export default function SessionListScreen() {
   const model = useSelector(selectedModel)
   const sessions = useSelector(sessionsSortedByTime)
   const isLoading = useSelector(store$.sessions.isLoading)
-  const isCreating = isLoading
+  const isCreating = useSelector(store$.sessions.isCreating)
   const isDeleting = false // TODO: Add per-session deletion state
   const isRefreshing = isLoading
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -281,7 +281,7 @@ export const actions = {
     },
 
     createSession: async () => {
-      store$.sessions.isLoading.set(true)
+      store$.sessions.isCreating.set(true)
 
       try {
         const session = await openCodeService.createSession()
@@ -296,7 +296,7 @@ export const actions = {
         )
         throw error
       } finally {
-        store$.sessions.isLoading.set(false)
+        store$.sessions.isCreating.set(false)
       }
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -27,6 +27,7 @@ export interface StoreState {
     list: Session[]
     current: string | null
     isLoading: boolean
+    isCreating: boolean
     error: string | null
   }
 
@@ -63,6 +64,7 @@ export const store$ = observable<StoreState>({
     list: [],
     current: null,
     isLoading: false,
+    isCreating: false,
     error: null,
   },
 


### PR DESCRIPTION
## Summary
- Fixes issue where refreshing session list incorrectly shows streaming state in InputBar
- Separates isLoading (for session fetching/refresh) from isCreating (for new session creation)
- InputBar now only shows streaming state when actually creating a session, not when refreshing

## Test plan
- [x] Refresh session list and verify InputBar doesn't show streaming state (red stop button)
- [x] Create new session and verify InputBar shows streaming state during creation
- [x] Verify RefreshControl still works properly during session list refresh

🤖 Generated with [opencode](https://opencode.ai)