### PR TITLE
feat: implement session abort functionality for streaming chat

### DIFF
--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -26,6 +26,7 @@ export interface InputBarProps {
   disabled?: boolean
   placeholder?: string
   isStreaming?: boolean
+  isAborting?: boolean
   currentModel?: string
   size?: '$2' | '$3' | '$4'
   borderWidth?: number
@@ -43,6 +44,7 @@ export function InputBar({
   disabled = false,
   placeholder = 'Type a message...',
   isStreaming = false,
+  isAborting = false,
   currentModel,
   size = '$2',
   borderWidth,
@@ -83,7 +85,7 @@ export function InputBar({
   }
 
   const handleStop = () => {
-    if (isStreaming) {
+    if (isStreaming && !isAborting) {
       onStop()
     }
   }
@@ -155,10 +157,13 @@ export function InputBar({
           icon={isStreaming ? StopCircle : ArrowUpCircle}
           scaleIcon={1.5}
           onPress={isStreaming ? handleStop : handleSubmit}
-          disabled={!isStreaming && !canSend}
+          disabled={(!isStreaming && !canSend) || isAborting}
+          animation={isAborting ? 'bouncy' : undefined}
+          animateOnly={isAborting ? ['opacity'] : undefined}
+          opacity={isAborting ? 0.7 : 1}
           pressStyle={{
             scale: 0.95,
-            backgroundColor: isStreaming ? '$red11' : '$blue11',
+            backgroundColor: isStreaming && !isAborting ? '$red11' : '$blue11',
           }}
         />
       </XStack>

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -239,6 +239,28 @@ class OpenCodeService {
     }
   }
 
+  async abortSession(sessionId: string): Promise<void> {
+    if (!this.client) {
+      throw new Error('Client not initialized')
+    }
+
+    try {
+      debug.log('Aborting session:', sessionId)
+      const response = await this.client.session.abort({
+        path: { id: sessionId },
+      })
+
+      if ('error' in response && response.error) {
+        throw new Error('Failed to abort session')
+      }
+
+      debug.success('Session aborted successfully:', sessionId)
+    } catch (error) {
+      debug.error('Failed to abort session:', error)
+      throw error
+    }
+  }
+
   // SSE event streaming using react-native-sse
   async *streamEvents(): AsyncGenerator<Event> {
     if (!this.config) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -42,6 +42,7 @@ export interface StoreState {
     bySessionId: Record<string, SessionMessageResponse[]>
     isLoading: boolean
     isSending: boolean
+    isAborting: boolean
     error: string | null
   }
 
@@ -92,6 +93,7 @@ export const store$ = observable<StoreState>({
     bySessionId: {},
     isLoading: false,
     isSending: false,
+    isAborting: false,
     error: null,
   },
 


### PR DESCRIPTION
## Summary

- Add complete session abort functionality to allow users to stop streaming chat sessions
- Implement service layer `abortSession` method with proper API integration  
- Add store state management with `isAborting` tracking and duplicate prevention
- Provide visual feedback in UI with disabled buttons and loading animations during abort
- Fix session event handling to properly clean up state after abort operations

This enhancement significantly improves UX by letting users immediately cancel long-running streaming responses instead of waiting for completion.